### PR TITLE
ci(tests): upload test app build as artifact

### DIFF
--- a/.github/workflows/ci.tests.yml
+++ b/.github/workflows/ci.tests.yml
@@ -17,4 +17,9 @@ jobs:
           node-version: '16'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
-      - run: yarn test:ember --reporter dot
+      - run: mkdir -p tmp
+      - run: yarn test:ember --reporter dot -o tmp/app
+      - uses: actions/upload-artifact@v2
+        with:
+          name: app
+          path: tmp/app/


### PR DESCRIPTION
Adds an artifact step:
<img width="1132" alt="Screen Shot 2021-12-10 at 2 51 38 PM" src="https://user-images.githubusercontent.com/1849508/145651282-d256a186-fc8b-41fe-88e5-df4f0c546a54.png">
which uploads the app used for testing in case post-test inspection is required:
<img width="1186" alt="Screen Shot 2021-12-10 at 2 53 20 PM" src="https://user-images.githubusercontent.com/1849508/145651303-8a971f0f-92f6-473c-b025-18a073cc470d.png">

