### PR TITLE
temp: expose walkthrough booking

### DIFF
--- a/app/routes/signup/walkthrough-booking.js
+++ b/app/routes/signup/walkthrough-booking.js
@@ -7,6 +7,11 @@ export default class SignupWalkthroughBookingRoute extends Route {
   async model() {
     // @todo
     // we are doing this while we only have 1 service area
-    return await this.store.findAll('service-area').get('firstObject');
+    const serviceAreas = await this.store.query('service-area', {
+      filter: {
+        zipcodes: ['78702'],
+      },
+    });
+    return serviceAreas.get('firstObject');
   }
 }


### PR DESCRIPTION
@achillesimperial in order for the walkthrough booking widget to work without starting the signup process from the beginning, we can expose it like so.

like we discussed, this is a scenario that expects the use to go through one thing (the zipcode first page of signup) before ever having a chance to get to the other thing (walkthrough booking which depends on the service area for the meeting calendar url).

so here, I am making it work by relying on the fact that right now we only have 1 service area. as soon as we have 2, this kind of thing will not work.