### PR TITLE
fix: move payment-approval redirect logic to session service

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -13,10 +13,7 @@ export default class IndexRoute extends Route {
   beforeModel() {
     // we are logged in
     // => go to dashboard.home
-    if (
-      this.session.isAuthenticated &&
-      this.session.data.authenticated.userinfo // don't redirect to dashboard if we logged in via payment-approval key
-    ) {
+    if (this.session.isAuthenticated) {
       this.router.transitionTo(NATIVE_MOBILE_ROUTE.DASHBOARD.HOME);
       return;
     }

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -16,6 +16,9 @@ export default class SessionService extends BaseSessionService {
   @service store;
 
   async handleAuthentication() {
+    if (this.data.authenticated.kind == 'payment-approval') {
+      return;
+    }
     super.handleAuthentication(...arguments);
     await this.loadIfPKCE();
   }


### PR DESCRIPTION
We need to make sure no redirection happens at all if auth'ed via payment-approval, so move that logic to the session service.