### PR TITLE
fix(work-order-status): loosen moment parser

### DIFF
--- a/app/data/work-order-status.js
+++ b/app/data/work-order-status.js
@@ -15,7 +15,7 @@ export const workOrderStatus = {
   problemBeingAddressed: 'problem_being_addressed',
   problemResolved: 'problem_resolved',
   vendorInvoiceReceived: 'vendor_invoice_received',
-  readyToInvoice: 'ready_to_invoice',
+  readyToInvoiceCustomer: 'ready_to_invoice_customer',
   invoiceSentToCustomer: 'invoice_sent_to_customer',
   invoicePaidByCustomer: 'invoice_paid_by_customer',
   paymentFailed: 'payment_failed',
@@ -47,7 +47,7 @@ export const workOrderStatusLabels = {
   [workOrderStatus.problemBeingAddressed]: 'Completed',
   [workOrderStatus.problemResolved]: 'Completed',
   [workOrderStatus.vendorInvoiceReceived]: 'Completed',
-  [workOrderStatus.readyToInvoice]: 'Completed',
+  [workOrderStatus.readyToInvoiceCustomer]: 'Completed',
   [workOrderStatus.invoiceSentToCustomer]: 'Payment Due',
   // [workOrderStatus.invoicePaidByCustomer]: 'Review Vendor', // For when review feature is developed.
   [workOrderStatus.invoicePaidByCustomer]: 'Paid',

--- a/app/utils/components/work-order/work-order-status.js
+++ b/app/utils/components/work-order/work-order-status.js
@@ -22,7 +22,7 @@ export const getWorkOrderTag = (status) => {
         type: 'accent',
       };
     case workOrderStatus.vendorInvoiceReceived:
-    case workOrderStatus.readyToInvoice:
+    case workOrderStatus.readyToInvoiceCustomer:
     case workOrderStatus.problemResolved:
     case workOrderStatus.problemBeingAddressed:
     case workOrderStatus.problemReported:
@@ -84,7 +84,7 @@ export const isActiveWorkOrder = (status) => {
     case workOrderStatus.problemBeingAddressed:
     case workOrderStatus.problemResolved:
     case workOrderStatus.vendorInvoiceReceived:
-    case workOrderStatus.readyToInvoice:
+    case workOrderStatus.readyToInvoiceCustomer:
     case workOrderStatus.invoiceSentToCustomer:
     case workOrderStatus.paymentFailed:
     case workOrderStatus.homeWalkthroughScheduled:
@@ -120,7 +120,7 @@ export const isHistoricalWorkOrder = (status) => {
     // case workOrderStatus.problemBeingAddressed:
     // case workOrderStatus.problemResolved:
     // case workOrderStatus.vendorInvoiceReceived:
-    // case workOrderStatus.readyToInvoice:
+    // case workOrderStatus.readyToInvoiceCustomer:
     // case workOrderStatus.invoiceSentToCustomer:
     // case workOrderStatus.paymentFailed:
     case workOrderStatus.invoicePaidByCustomer:
@@ -143,7 +143,7 @@ export const isCompletedWorkOrder = (status) => {
     case workOrderStatus.problemBeingAddressed:
     case workOrderStatus.problemResolved:
     case workOrderStatus.vendorInvoiceReceived:
-    case workOrderStatus.readyToInvoice:
+    case workOrderStatus.readyToInvoiceCustomer:
     case workOrderStatus.walkthroughCompleted:
       return true;
     default:


### PR DESCRIPTION
I am finding that:

```js
moment('12/21/2021', 'MM/DD/YY') < moment('06/21/2022', 'MM/DD/YY') //=> false (wrong)
```

but
```js
moment('12/21/2021') < moment('06/21/2022') //=> true (right)
```

works just fine. validated the parsing on the individual parts.

@achillesimperial That bit of code seemed intentional, will this change break anything?