### PR TITLE
chore(ci/cd): use concurrency lock on testflight release workflow

### DIFF
--- a/.github/workflows/cd.release.testflight.yml
+++ b/.github/workflows/cd.release.testflight.yml
@@ -1,5 +1,7 @@
 name: cd / release
 
+concurrency: testflight-release-lock
+
 on:
   release:
     types:


### PR DESCRIPTION
prevent more than one of these running at the same time